### PR TITLE
Add company view page, templater class and related admin functionality

### DIFF
--- a/includes/admin/pilot-admin.php
+++ b/includes/admin/pilot-admin.php
@@ -6,7 +6,29 @@ function pilot_admin_page_html() {
   }
   ?>
   <div class="wrap">
-    <h1><?php echo esc_html(get_admin_page_title()); ?></h1>
+    <h1>Administrator tools</h1>
+    <form name="post" action="/view_results" method="post">
+      <fieldset>
+        <legend><h2>View company results</h2></legend>
+        <p>
+          <label>Select which company's results to view</label>
+          <select name="company_view_for_admin">
+
+            <?php
+            $companies = get_users( array('role' => 'company') );
+            foreach($companies as $company){
+              echo '<option value="' . $company->ID . '">' . $company->data->user_login . '</option>';
+            }
+            ?>
+
+          </select>
+        </p>
+      </fieldset>
+      <input type="submit" value="View results" >
+    </form>
+
+
+    <h1>Administrator options</h1>
     <form action="options.php" method="post">
       <?php
             settings_fields('pilot_configurator_settings');
@@ -26,7 +48,7 @@ function pilot_admin_page_settings_init() {
   // register 'settings_priority_section' section on the 'pilot_configurator' page
   add_settings_section(
     'settings_priority_section',
-    'Question value options',
+    'Question value',
     'settings_priority_section_cb',
     'pilot_configurator'
   );
@@ -56,21 +78,21 @@ function pilot_admin_page_settings_init() {
   // register 'settings_priority_value_#' field in the "settings_priority_section" section
   add_settings_field(
     'settings_priority_value_1',
-    'PRIORITY_1_STRING',
+    '"Ei tärkeä"',
     'setting_priority_1_cb',
     'pilot_configurator',
     'settings_priority_section'
     );
   add_settings_field(
     'settings_priority_value_2',
-    'PRIORITY_2_STRING',
+    '"Tärkeä"',
     'setting_priority_2_cb',
     'pilot_configurator',
     'settings_priority_section'
     );
   add_settings_field(
     'settings_priority_value_3',
-    'PRIORITY_3_STRING',
+    '"Hyvin tärkeä"',
     'setting_priority_3_cb',
     'pilot_configurator',
     'settings_priority_section'
@@ -104,5 +126,6 @@ function pilot_admin_page_settings_init() {
     $options = get_option('inno_oppiva_priorities');
     echo "<input id='inno_oppiva_secret' name='inno_oppiva_priorities[3]' size='3' type='number' step='1' value='{$options['3']}' />";
   }
+  
   
 }

--- a/includes/class-page-templater.php
+++ b/includes/class-page-templater.php
@@ -1,0 +1,156 @@
+<?php
+/**
+  * Class to create custom page templates within plugin
+  * 
+  */
+
+namespace Inno_Oppiva;
+
+if ( ! defined( 'ABSPATH' ) ) {
+   die('Access Denied!');
+}
+
+if ( ! class_exists('Page_Templater') ) {
+
+   class Page_Templater {
+
+      /**
+      * A reference to an instance of this class.
+      */
+      private static $instance;
+
+      /**
+      * The array of templates that this plugin tracks.
+      */
+      protected $templates;
+
+      /**
+       * Initialization
+       */
+      public function init(){
+         add_action( 'plugins_loaded', array( $this, 'get_instance' ));
+      }
+
+      /**
+      * Returns an instance of this class. 
+      */
+      public static function get_instance() {
+
+      if ( null == self::$instance ) {
+         self::$instance = new Page_Templater();
+      } 
+
+      return self::$instance;
+
+      } 
+
+      /**
+      * Initializes the plugin by setting filters and administration functions.
+      */
+      public function __construct() {
+
+         $this->templates = array();
+
+         // Add a filter to the wp 4.7 version attributes metabox
+         add_filter(
+            'theme_page_templates', array( $this, 'add_new_template' )
+         );
+
+         // Add a filter to the save post to inject out template into the page cache
+         add_filter(
+            'wp_insert_post_data', 
+            array( $this, 'register_project_templates' ) 
+         );
+
+
+         // Add a filter to the template include to determine if the page has our 
+         // template assigned and return it's path
+         add_filter(
+            'template_include', 
+            array( $this, 'view_project_template') 
+         );
+
+
+         // Add your templates to this array.
+         $this->templates = array(
+            'templates/template-company-view.php' => 'Company View',
+         );
+
+      } 
+
+      /**
+      * Adds our template to the page dropdown for v4.7+
+      *
+      */
+      public function add_new_template( $posts_templates ) {
+         $posts_templates = array_merge( $posts_templates, $this->templates );
+         return $posts_templates;
+      }
+
+      /**
+      * Adds our template to the pages cache in order to trick WordPress
+      * into thinking the template file exists where it doens't really exist.
+      */
+      public function register_project_templates( $atts ) {
+
+         // Create the key used for the themes cache
+         $cache_key = 'page_templates-' . md5( get_theme_root() . '/' . get_stylesheet() );
+
+         // Retrieve the cache list. 
+         // If it doesn't exist, or it's empty prepare an array
+         $templates = wp_get_theme()->get_page_templates();
+         if ( empty( $templates ) ) {
+            $templates = array();
+         } 
+
+         // New cache, therefore remove the old one
+         wp_cache_delete( $cache_key , 'themes');
+
+         // Now add our template to the list of templates by merging our templates
+         // with the existing templates array from the cache.
+         $templates = array_merge( $templates, $this->templates );
+
+         // Add the modified cache to allow WordPress to pick it up for listing
+         // available templates
+         wp_cache_add( $cache_key, $templates, 'themes', 1800 );
+
+         return $atts;
+
+      } 
+
+      /**
+      * Checks if the template is assigned to the page
+      */
+      public function view_project_template( $template ) {
+
+         // Get global post
+         global $post;
+
+         // Return template if post is empty
+         if ( ! $post ) {
+            return $template;
+         }
+
+         // Return default template if we don't have a custom one defined
+         if ( ! isset( $this->templates[get_post_meta( $post->ID, '_wp_page_template', true )] ) ) {
+            return $template;
+         } 
+
+         $file = plugin_dir_path( __FILE__ ). get_post_meta( 
+            $post->ID, '_wp_page_template', true
+         );
+
+         // Just to be safe, we check if the file exist first
+         if ( file_exists( $file ) ) {
+            return $file;
+         } else {
+            echo $file;
+         }
+
+         // Return template
+         return $template;
+
+      }
+
+   } 
+}

--- a/includes/pages/company-view.php
+++ b/includes/pages/company-view.php
@@ -1,0 +1,34 @@
+<?php
+
+function create_company_view() {
+	global $wpdb;
+
+	$slug = 'view_results';
+	
+	if( null == get_page_by_path( $slug, 'OBJECT', 'page') ) {
+
+		wp_insert_post(
+			array(
+				'comment_status'	=>	'closed',
+				'ping_status'		=>	'closed',
+				'post_author'		=>	'1',
+				'post_name'			=>	$slug,
+				'post_title'		=>	'View Results',
+				'post_content'		=>	'',
+				'post_status'		=>	'publish',
+				'post_type'			=>	'page',
+				'page_template'	=> 'templates/template-company-view.php'
+			)
+		);
+	}
+}
+
+function remove_company_view() {
+   global $wpdb;
+	$table_name = $wpdb->prefix . 'posts';
+
+	$slug = 'view_results';
+   
+   $result = $wpdb->get_row("SELECT ID FROM " . $table_name . " WHERE post_name='" . $slug . "'", 'ARRAY_N');
+	wp_delete_post($result[0], true);
+}

--- a/includes/templates/template-company-view.php
+++ b/includes/templates/template-company-view.php
@@ -1,0 +1,111 @@
+<?php
+/*
+ * Template name: Company View
+ * Description: A modified page.php page template that handles calculations for company view
+ * 
+ */
+
+
+get_header(); ?>
+
+<div class="wrap">
+	<div id="primary" class="content-area">
+		<main id="main" class="site-main" role="main">
+
+			<?php
+
+         global $wpdb;
+         // Check for administrator checking a company's results
+         if ( current_user_can( 'administrator' ) ) {
+            if( isset( $_POST['company_view_for_admin'] ) ) {
+               $company_id = $_POST['company_view_for_admin'];       
+            }
+            else{
+               echo "Please use the administrator page to view a specific company's results"; 
+               die;
+            }
+         }
+         else{
+            $company_id = get_current_user_id(); 
+         }
+         echo '<h1>Results for ' . get_user_by('id', $company_id)->user_nicename . '</h1>';
+
+         $company_answer_table = $wpdb->prefix . 'Company_answer';
+         $school_answer_table = $wpdb->prefix . 'School_answer';
+
+         /* alternative query implementation
+         $company_answers = $wpdb->get_results(
+            "SELECT question_id, answer_max, answer_min, answer_priority
+            FROM $company_answer_table
+            WHERE company_id=$company_id
+            ORDER BY question_id ASC");
+
+         $school_answers = $wpdb->get_results(
+            "SELECT school_id, answer, question_id
+            FROM $school_answer_table
+            WHERE company_id=$company_id
+            ORDER BY school_id ASC, question_id ASC");
+         */
+         
+         $query_result = $wpdb->get_results(
+            "SELECT school_id, answer_val AS answer, $school_answer_table.question_id, answer_max, answer_min, answer_priority
+            FROM $school_answer_table
+            INNER JOIN (SELECT question_id, answer_max, answer_min, answer_priority
+                        FROM $company_answer_table
+                        WHERE company_id=$company_id
+                        ) AS company_answer_query ON $school_answer_table.question_id=company_answer_query.question_id
+            WHERE company_id=$company_id
+            ORDER BY school_id ASC, question_id ASC");
+
+         /* 
+          * SQL-query result will be turned into an array of school_ids that
+          * all have an array which consist of that school's answers to the
+          * company in question
+          */
+         $school_id_column = array_column($query_result, 'school_id');
+         $school_ids = array_unique($school_id_column);
+         $query_result_organized = array();
+         foreach($school_ids as $school_id){
+            $query_result_organized[$school_id] =  array();
+         }
+
+         foreach($query_result as $result){
+            $query_result_organized[$result->school_id][] = 
+               array('question_id' => $result->question_id, 
+                     'answer' => $result->answer,
+                     'answer_max' => $result->answer_max,
+                     'answer_min' => $result->answer_min,
+                     'answer_priority' => $result->answer_priority);
+         }
+
+         // Record the content of company view
+         ob_start();
+         foreach($school_ids as $school_id){
+            if(count($query_result_organized[$school_id]) == 23){
+               $school_name = get_user_by('id', $school_id)->user_nicename;
+               
+               $match = match_alg($query_result_organized[$school_id]);
+               echo '<details><summary>' . $school_name . ' ' . $match . '%</summary> .
+                     <span id=more_' . $school_id . '><p>hey</p></span></details>';
+            }
+         }
+         $company_view_content = ob_get_contents(); 
+         ob_end_clean();
+
+         // Loop from page.php
+         while ( have_posts() ) :
+				the_post();
+				//get_template_part( 'template-parts/page/content', 'page' ); // prints unwanted post data 
+            echo $company_view_content; // Insert custom content
+				// Fetching comments removed
+			endwhile;
+         
+			?>
+
+		</main><!-- #main -->
+	</div><!-- #primary -->
+</div><!-- .wrap -->
+
+<?php
+get_footer();
+

--- a/pilot-configurator.php
+++ b/pilot-configurator.php
@@ -38,6 +38,9 @@ require PILOT_CONFIGURATOR_DIR_PATH . 'includes/admin/class-pilot-configurator-a
 require PILOT_CONFIGURATOR_DIR_PATH . 'includes/class-inno-oppiva-login.php';
 require PILOT_CONFIGURATOR_DIR_PATH . 'includes/inno-user-roles.php';
 require PILOT_CONFIGURATOR_DIR_PATH . 'includes/match-algorithm.php';
+require PILOT_CONFIGURATOR_DIR_PATH . 'includes/class-page-templater.php';
+
+require PILOT_CONFIGURATOR_DIR_PATH . 'includes/pages/company-view.php';
 
 register_activation_hook (__FILE__, 'add_inno_user_roles');
 register_deactivation_hook (__FILE__, 'remove_inno_user_roles');
@@ -107,7 +110,13 @@ function ajax_test_enqueue_scripts() {
 	
 }
 
+function page_templater_init(){
+	$page_templater = new Inno_Oppiva\Page_Templater();
+	$page_templater->init();
+}
 
+register_activation_hook (__FILE__, 'create_company_view');
+register_deactivation_hook (__FILE__, 'remove_company_view');
 
 /**
   * Begins the execution of the plugin. Pilot_Configurator_Admin is required only when
@@ -124,4 +133,5 @@ function pilot_configurator_init() {
   }
 }
 inno_oppiva_init();
+page_templater_init();
 pilot_configurator_init();


### PR DESCRIPTION
Add new class to handle creating page templates on the plugin side, based on an open source plugin
Add view_results page for companies to see all matches they have and serve as the base page for the rest of the company's view functionality. view_page uses custom page template template_view_page that does everything on the page, it also does an sql query for all relevant data and rearranges it to a more easily usable form
Add admin functionality to view company results as admin from the pilot_configurator admin page



