### PR TITLE
Fixed database-insertions

### DIFF
--- a/includes/class-inno-oppiva-login.php
+++ b/includes/class-inno-oppiva-login.php
@@ -21,6 +21,7 @@ if ( ! class_exists('Inno_Oppiva_Login') ) {
       add_action( 'wp_login', array( $this, 'inno_oppiva_cookie_set' ), 10, 2 );
       add_action( 'wp_logout', array( $this, 'inno_oppiva_cookie_clear' ), 10, 2 );
       add_action( 'wp_login', array( $this, 'inno_oppiva_redirect_to_splash' ), 10, 2 );
+	  //add_action('wp_login', array( $this, 'company_check_productpage' ), 10, 2);
     }
 
     public function inno_oppiva_cookie_set( $user_login, $user ) {
@@ -59,5 +60,25 @@ if ( ! class_exists('Inno_Oppiva_Login') ) {
       }
 
     }
+	/*
+	public function company_check_productpage( $user_login, $user){
+		global $wpdb;
+		
+		if ( user_can( $user, 'company' ) ){
+			
+			$nicename = $wpdb->get_var("SELECT user_nicename FROM wp_users WHERE ID = $user->ID");
+			$result = $wpdb->get_row("SELECT * FROM wp_posts WHERE post_name = $nicename");
+			
+			if( results == NULL ){
+				require_once (dirname(__FILE__) . '/createpost/createpost.php');
+				create_productpage( $nicename, $user->ID);
+				exit;
+			}
+			exit;
+		}
+			
+		exit;
+	}
+	*/
   }
 }

--- a/includes/javascript/companyLister.js
+++ b/includes/javascript/companyLister.js
@@ -17,9 +17,33 @@ jQuery( document ).ready(function($) {
 				},
 				success : function( response ) {
 					// Replaces the element text with the companies
-					companylist.innerText = companylist.textContent = response;
+					companylist.innerHTML = response;
 				}
 			});
 		
 	}
 });
+
+function giveCompanyCookie(CID){
+	
+	// + '://' + window.location.hostname + 'school_question1'
+	var pagepath = window.location.protocol;
+	pagepath = pagepath + "//" + window.location.hostname + "/school_question1";
+	
+	console.log(pagepath);
+	jQuery.ajax({
+		
+		url : company_lister.ajax_url,
+		type : 'POST',
+		data : {
+					'action' : 'company_id_cookie_set',
+					'cont' : CID
+			},
+		success : function( response ) {
+				console.log(response);
+				window.location.href = pagepath;
+			}
+		});
+		
+	
+}

--- a/pilot-configurator.php
+++ b/pilot-configurator.php
@@ -39,6 +39,9 @@ require PILOT_CONFIGURATOR_DIR_PATH . 'includes/class-inno-oppiva-login.php';
 require PILOT_CONFIGURATOR_DIR_PATH . 'includes/inno-user-roles.php';
 require PILOT_CONFIGURATOR_DIR_PATH . 'includes/match-algorithm.php';
 
+require (dirname(__FILE__) . '/includes/questionaire-creation.php');
+require (dirname(__FILE__) . '/includes/splash_creation/create_splash.php');
+
 register_activation_hook (__FILE__, 'add_inno_user_roles');
 register_deactivation_hook (__FILE__, 'remove_inno_user_roles');
 
@@ -57,8 +60,6 @@ function inno_oppiva_init() {
   $inno_oppiva_login->init();
 }
 
-require (dirname(__FILE__) . '/includes/questionaire-creation.php');
-require (dirname(__FILE__) . '/includes/splash_creation/create_splash.php');
 
 
 remove_filter( 'the_content', 'wpautop' );
@@ -73,6 +74,7 @@ register_deactivation_hook (__FILE__, 'remove_splashes');
 add_action('wp_ajax_list_active_companies', 'list_active_companies');
 add_action('wp_ajax_school_question_insert', 'school_question_insert');
 add_action('wp_ajax_company_question_insert', 'company_question_insert');
+add_action('wp_ajax_company_id_cookie_set', 'company_id_cookie_set');
 
 
 register_activation_hook (__FILE__, 'ajax_test_enqueue_scripts');


### PR DESCRIPTION
Fixes the issue where the question forms could create multiples of the same answer.

Closes issue #19 

Adds the cookie-identification to the school-question forms allowing for the school database insertions

Closes issue #14 

Suggestions on testing:

Test out both splash-pages that they redirect to the correct page.

Test answering the questions and see if multiples of the same answer exist